### PR TITLE
add datetime property to participated_in associations

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "lattice-ui-kit": "0.25.0",
     "lodash": "~4.17.10",
     "loglevel": "~1.6.0",
+    "luxon": "~1.21.0",
     "polished": "~3.4.0",
     "react": "~16.12.0",
     "react-dom": "~16.12.0",

--- a/src/containers/studies/StudiesReducer.js
+++ b/src/containers/studies/StudiesReducer.js
@@ -34,7 +34,7 @@ import {
 import { PROPERTY_TYPE_FQNS } from '../../core/edm/constants/FullyQualifiedNames';
 import { RESET_REQUEST_STATE } from '../../core/redux/ReduxActions';
 
-const { STATUS, STUDY_ID } = PROPERTY_TYPE_FQNS;
+const { DATE_ENROLLED, STATUS, STUDY_ID } = PROPERTY_TYPE_FQNS;
 
 const INITIAL_STATE :Map<*, *> = fromJS({
   [ADD_PARTICIPANT]: {
@@ -225,9 +225,15 @@ export default function studiesReducer(state :Map<*, *> = INITIAL_STATE, action 
         REQUEST: () => state.setIn([CHANGE_ENROLLMENT_STATUS, 'requestState'], RequestStates.PENDING),
         FAILURE: () => state.setIn([CHANGE_ENROLLMENT_STATUS, 'requestState'], RequestStates.FAILURE),
         SUCCESS: () => {
-          const { newEnrollmentStatus, participantEntityKeyId, studyId } = seqAction.value;
+          const {
+            enrollmentDate,
+            newEnrollmentStatus,
+            participantEntityKeyId,
+            studyId
+          } = seqAction.value;
           return state
             .setIn(['participants', studyId, participantEntityKeyId, STATUS], [newEnrollmentStatus])
+            .setIn(['participants', studyId, participantEntityKeyId, DATE_ENROLLED], [enrollmentDate])
             .setIn([CHANGE_ENROLLMENT_STATUS, 'requestState'], RequestStates.SUCCESS);
         }
       });

--- a/src/containers/study/ParticipantsTable.js
+++ b/src/containers/study/ParticipantsTable.js
@@ -12,6 +12,7 @@ import DeleteParticipantModal from './components/DeleteParticipantModal';
 import DownloadParticipantDataModal from './components/DownloadParticipantDataModal';
 import ParticipantInfoModal from './components/ParticipantInfoModal';
 import ParticipantRow from './components/ParticipantRow';
+import TABLE_HEADERS from './utils/tableHeaders';
 
 import ParticipantActionTypes from '../../utils/constants/ParticipantActionTypes';
 import { PROPERTY_TYPE_FQNS } from '../../core/edm/constants/FullyQualifiedNames';
@@ -30,22 +31,6 @@ const {
   LINK,
   TOGGLE_ENROLLMENT
 } = ParticipantActionTypes;
-
-const tableHeader = [
-  {
-    key: PERSON_ID,
-    label: 'Participant ID',
-  },
-  {
-    cellStyle: {
-      textAlign: 'center',
-      width: '180px',
-    },
-    key: 'actions',
-    label: 'Actions',
-    sortable: false
-  },
-];
 
 const TableWrapper = styled.div`
   margin-top: 20px;
@@ -136,7 +121,7 @@ const ParticipantsTable = (props :Props) => {
         <Table
             components={components}
             data={participants.valueSeq().toJS()}
-            headers={tableHeader}
+            headers={TABLE_HEADERS}
             paginated
             rowsPerPageOptions={[5, 20, 50]} />
       </TableWrapper>

--- a/src/containers/study/components/ParticipantRow.js
+++ b/src/containers/study/components/ParticipantRow.js
@@ -17,8 +17,9 @@ import { Colors } from 'lattice-ui-kit';
 import EnrollmentStatuses from '../../../utils/constants/EnrollmentStatus';
 import ParticipantActionTypes from '../../../utils/constants/ParticipantActionTypes';
 import { PROPERTY_TYPE_FQNS } from '../../../core/edm/constants/FullyQualifiedNames';
+import { getDateTimeFromIsoDate } from '../../../utils/DateUtils';
 
-const { PERSON_ID, STATUS } = PROPERTY_TYPE_FQNS;
+const { PERSON_ID, STATUS, DATE_ENROLLED } = PROPERTY_TYPE_FQNS;
 const { NEUTRALS, PURPLES } = Colors;
 const { ENROLLED } = EnrollmentStatuses;
 const {
@@ -120,6 +121,7 @@ const ParticipantRow = (props :Props) => {
   const participantEKId = getIn(data, ['id', 0]);
   const participantId = getIn(data, [PERSON_ID, 0]);
   const enrollmentStatus = getIn(data, [STATUS, 0]);
+  const enrollmentDate = getDateTimeFromIsoDate(getIn(data, [DATE_ENROLLED, 0]));
 
   const toggleIcon = enrollmentStatus === ENROLLED ? faToggleOn : faToggleOff;
   const actionsData = [
@@ -135,6 +137,12 @@ const ParticipantRow = (props :Props) => {
         <StyledCell>
           <CellContent>
             { participantId }
+          </CellContent>
+        </StyledCell>
+
+        <StyledCell>
+          <CellContent>
+            { enrollmentDate }
           </CellContent>
         </StyledCell>
 

--- a/src/containers/study/utils/tableHeaders.js
+++ b/src/containers/study/utils/tableHeaders.js
@@ -1,0 +1,31 @@
+// @flow
+
+import { PROPERTY_TYPE_FQNS } from '../../../core/edm/constants/FullyQualifiedNames';
+
+const { PERSON_ID, DATE_ENROLLED } = PROPERTY_TYPE_FQNS;
+const TABLE_HEADERS = [
+  {
+    key: PERSON_ID,
+    label: 'Participant ID',
+    cellStyle: {
+      width: '40%',
+    }
+  },
+  {
+    key: DATE_ENROLLED,
+    label: 'Enrollment Date',
+    cellStyle: {
+      width: '40%',
+    }
+  },
+  {
+    key: 'actions',
+    label: 'Actions',
+    sortable: false,
+    cellStyle: {
+      textAlign: 'center',
+    }
+  },
+];
+
+export default TABLE_HEADERS;

--- a/src/core/edm/constants/FullyQualifiedNames.js
+++ b/src/core/edm/constants/FullyQualifiedNames.js
@@ -22,7 +22,8 @@ const PROPERTY_TYPE_FQNS = {
 
   // study participants:
   PERSON_ID: new FullyQualifiedName('nc.SubjectIdentification'),
-  STATUS: new FullyQualifiedName('ol.status')
+  STATUS: new FullyQualifiedName('ol.status'),
+  DATE_ENROLLED: new FullyQualifiedName('ol.datetimestart')
 };
 
 export {

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -1,0 +1,16 @@
+// @flow
+import { DateTime } from 'luxon';
+
+// @return 10/20/2020, 1:30 PM
+const getDateTimeFromIsoDate = (isoDate :string) => {
+  console.log('date', isoDate);
+  const date :DateTime = DateTime.fromISO(isoDate);
+  if (date.isValid) {
+    return date.toLocaleString(DateTime.DATETIME_SHORT);
+  }
+  return null;
+};
+
+export {
+  getDateTimeFromIsoDate
+};


### PR DESCRIPTION
Add enrollment date for participants. When participants are unenrolled from a study, the datetime property is set to null and the corresponding row in the participants table has a blank entry for the date.


<img width="1007" alt="date" src="https://user-images.githubusercontent.com/15723547/74472004-108c3700-4e56-11ea-8ed5-7b01c7ffa3a9.png">
