### PR TITLE
filter out invalid study entities

### DIFF
--- a/src/containers/studies/StudiesSagas.js
+++ b/src/containers/studies/StudiesSagas.js
@@ -1024,7 +1024,7 @@ function* getStudiesWorker(action :SequenceAction) :Generator<*, *, *> {
     if (response.error) {
       throw response.error;
     }
-    const studies = fromJS(response.data);
+    const studies = fromJS(response.data).filter((study) => study.getIn([STUDY_ID, 0]));
 
     response = yield call(
       getStudyAuthorizationsWorker,


### PR DESCRIPTION
get rid of `getEntitySetId(chronicle_participants_undefined)` calls

![Screen Shot 2020-03-04 at 9 14 05 AM](https://user-images.githubusercontent.com/15723547/76014938-51b0bd80-5ecf-11ea-9378-c2854729043d.png)
