### PR TITLE
filter out studies whose access to notification entity sets is unauthorized

### DIFF
--- a/src/core/permissions/PermissionsActions.js
+++ b/src/core/permissions/PermissionsActions.js
@@ -3,6 +3,9 @@
 import { newRequestSequence } from 'redux-reqseq';
 import type { RequestSequence } from 'redux-reqseq';
 
+const GET_NOTIFICATIONS_AUTHORIZATIONS :'GET_NOTIFICATIONS_AUTHORIZATIONS' = 'GET_NOTIFICATIONS_AUTHORIZATIONS';
+const getNotificationsAuthorizations = newRequestSequence(GET_NOTIFICATIONS_AUTHORIZATIONS);
+
 const GET_STUDY_AUTHORIZATIONS :'GET_STUDY_AUTHORIZATIONS' = 'GET_STUDY_AUTHORIZATIONS';
 const getStudyAuthorizations :RequestSequence = newRequestSequence(GET_STUDY_AUTHORIZATIONS);
 
@@ -10,8 +13,10 @@ const UPDATE_ES_PERMISSIONS :'UPDATE_ES_PERMISSIONS' = 'UPDATE_ES_PERMISSIONS';
 const updateEntitySetPermissions :RequestSequence = newRequestSequence(UPDATE_ES_PERMISSIONS);
 
 export {
+  GET_NOTIFICATIONS_AUTHORIZATIONS,
   GET_STUDY_AUTHORIZATIONS,
   UPDATE_ES_PERMISSIONS,
+  getNotificationsAuthorizations,
   getStudyAuthorizations,
   updateEntitySetPermissions,
 };

--- a/src/core/permissions/PermissionsReducer.js
+++ b/src/core/permissions/PermissionsReducer.js
@@ -4,8 +4,10 @@ import { Map, fromJS } from 'immutable';
 import { RequestStates } from 'redux-reqseq';
 
 import {
-  UPDATE_ES_PERMISSIONS,
+  GET_NOTIFICATIONS_AUTHORIZATIONS,
   GET_STUDY_AUTHORIZATIONS,
+  UPDATE_ES_PERMISSIONS,
+  getNotificationsAuthorizations,
   getStudyAuthorizations,
   updateEntitySetPermissions
 } from './PermissionsActions';
@@ -15,6 +17,9 @@ const INITIAL_STATE :Map = fromJS({
     requestState: RequestStates.STANDBY
   },
   [UPDATE_ES_PERMISSIONS]: {
+    requestState: RequestStates.STANDBY
+  },
+  [GET_NOTIFICATIONS_AUTHORIZATIONS]: {
     requestState: RequestStates.STANDBY
   }
 });
@@ -34,6 +39,14 @@ export default function permissionsReducer(state :Map = INITIAL_STATE, action :O
         REQUEST: () => state.setIn([GET_STUDY_AUTHORIZATIONS, 'requestState'], RequestStates.PENDING),
         FAILURE: () => state.setIn([GET_STUDY_AUTHORIZATIONS, 'requestState'], RequestStates.FAILURE),
         SUCCESS: () => state.setIn([GET_STUDY_AUTHORIZATIONS, 'requestState'], RequestStates.SUCCESS)
+      });
+    }
+
+    case getNotificationsAuthorizations.case(action.type): {
+      return getNotificationsAuthorizations.reducer(state, action, {
+        REQUEST: () => state.setIn([GET_NOTIFICATIONS_AUTHORIZATIONS, 'requestState'], RequestStates.PENDING),
+        FAILURE: () => state.setIn([GET_NOTIFICATIONS_AUTHORIZATIONS, 'requestState'], RequestStates.FAILURE),
+        SUCCESS: () => state.setIn([GET_NOTIFICATIONS_AUTHORIZATIONS, 'requestState'], RequestStates.SUCCESS)
       });
     }
 

--- a/src/core/permissions/PermissionsSagas.js
+++ b/src/core/permissions/PermissionsSagas.js
@@ -226,7 +226,7 @@ function* getStudyAuthorizationsWatcher() :Generator<*, *, *> {
 
 /*
  *
- * PermissionsActions.getStudyAuthorizations()
+ * PermissionsActions.getNotificationsAuthorizations()
  *
  */
 
@@ -253,11 +253,11 @@ function* getNotificationsAuthorizationsWorker(action :SequenceAction) :Generato
     Object.entries(response).forEach(([esName, value]) => {
       const tokens = esName.split('_');
 
-      const errorRes = get(value, 'error');
+      const error = get(value, 'error');
       const data = get(value, 'data');
 
-      if (errorRes instanceof Error) {
-        if (errorRes.response.status === 401 && errorRes.response.statusText === 'Unauthorized') {
+      if (error instanceof Error) {
+        if (error.response.status === 401 && error.response.statusText === 'Unauthorized') {
           unauthorizedStudyIds.push(tokens[2]);
         }
       }


### PR DESCRIPTION
PR: 
Only display studies whose `getEntitySetId` on the corresponding notifications / part_of entity sets does not result in 401 status code.
