### PR TITLE
Task/apps 2037 single notifications entityset

### DIFF
--- a/src/containers/app/AppSagas.js
+++ b/src/containers/app/AppSagas.js
@@ -21,8 +21,8 @@ import {
   getAllEntitySetIdsWorker,
   getEntityDataModelTypesWorker,
 } from '../../core/edm/EDMSagas';
-import { getStudies } from '../studies/StudiesActions';
-import { getStudiesWorker } from '../studies/StudiesSagas';
+import { getStudies, getGlobalNotificationsEKID } from '../studies/StudiesActions';
+import { getStudiesWorker, getGlobalNotificationsEKIDWorker } from '../studies/StudiesSagas';
 
 const LOG = new Logger('AppSagas');
 
@@ -45,7 +45,11 @@ function* initializeApplicationWorker(action :SequenceAction) :Generator<*, *, *
       if (res.error) throw res.error;
     });
     // get all studies only after getting entitySetIds
-    const response = yield call(getStudiesWorker, getStudies());
+    let response = yield call(getStudiesWorker, getStudies());
+    if (response.error) throw response.error;
+
+    // get entity key id of entity in global notifications entity set
+    response = yield call(getGlobalNotificationsEKIDWorker, getGlobalNotificationsEKID());
     if (response.error) throw response.error;
 
     yield put(initializeApplication.success(action.id));

--- a/src/containers/studies/StudiesActions.js
+++ b/src/containers/studies/StudiesActions.js
@@ -23,6 +23,9 @@ const createStudy :RequestSequence = newRequestSequence(CREATE_STUDY);
 const DELETE_STUDY_PARTICIPANT :'DELETE_STUDY_PARTICIPANT' = 'DELETE_STUDY_PARTICIPANT';
 const deleteStudyParticipant :RequestSequence = newRequestSequence(DELETE_STUDY_PARTICIPANT);
 
+const GET_GLOBAL_NOTIFICATIONS_EKID :'GET_GLOBAL_NOTIFICATIONS_EKID' = 'GET_GLOBAL_NOTIFICATIONS_EKID';
+const getGlobalNotificationsEKID = newRequestSequence(GET_GLOBAL_NOTIFICATIONS_EKID);
+
 const GET_PARTICIPANTS_ENROLLMENT :'GET_PARTICIPANTS_ENROLLMENT' = 'GET_PARTICIPANTS_ENROLLMENT';
 const getParticipantsEnrollmentStatus :RequestSequence = newRequestSequence(GET_PARTICIPANTS_ENROLLMENT);
 
@@ -45,6 +48,7 @@ export {
   CREATE_PARTICIPANTS_ENTITY_SET,
   CREATE_STUDY,
   DELETE_STUDY_PARTICIPANT,
+  GET_GLOBAL_NOTIFICATIONS_EKID,
   GET_PARTICIPANTS_ENROLLMENT,
   GET_STUDIES,
   GET_STUDY_NOTIFICATION_STATUS,
@@ -56,6 +60,7 @@ export {
   createParticipantsEntitySet,
   createStudy,
   deleteStudyParticipant,
+  getGlobalNotificationsEKID,
   getParticipantsEnrollmentStatus,
   getStudies,
   getStudyNotificationStatus,

--- a/src/containers/studies/StudiesReducer.js
+++ b/src/containers/studies/StudiesReducer.js
@@ -5,7 +5,8 @@
 import {
   Map,
   fromJS,
-  getIn
+  getIn,
+  Set
 } from 'immutable';
 import { Constants } from 'lattice';
 import { RequestStates } from 'redux-reqseq';
@@ -303,7 +304,7 @@ export default function studiesReducer(state :Map<*, *> = INITIAL_STATE, action 
         FAILURE: () => state.setIn([GET_STUDY_NOTIFICATION_STATUS, 'requestState'], RequestStates.FAILURE),
         SUCCESS: () => state
           .setIn([GET_STUDY_NOTIFICATION_STATUS, 'requestState'], RequestStates.SUCCESS)
-          .set('studyNotifications', fromJS(seqAction.value))
+          .set('studiesWithNotifications', Set(seqAction.value))
       });
     }
 

--- a/src/containers/studies/StudiesReducer.js
+++ b/src/containers/studies/StudiesReducer.js
@@ -6,13 +6,9 @@ import {
   Map,
   Set,
   fromJS,
-  getIn
 } from 'immutable';
-import { Constants } from 'lattice';
 import { RequestStates } from 'redux-reqseq';
 import type { SequenceAction } from 'redux-reqseq';
-
-import { STUDIES_REDUCER_CONSTANTS } from '../../utils/constants/ReduxConstants';
 
 import {
   ADD_PARTICIPANT,
@@ -43,20 +39,15 @@ import {
 
 import { PROPERTY_TYPE_FQNS } from '../../core/edm/constants/FullyQualifiedNames';
 import { RESET_REQUEST_STATE } from '../../core/redux/ReduxActions';
+import { STUDIES_REDUCER_CONSTANTS } from '../../utils/constants/ReduxConstants';
 
-const { OPENLATTICE_ID_FQN } = Constants;
-
-const {
-  DATE_ENROLLED,
-  NOTIFICATION_ID,
-  STATUS,
-  STUDY_ID,
-} = PROPERTY_TYPE_FQNS;
+const { DATE_ENROLLED, STATUS } = PROPERTY_TYPE_FQNS;
 
 const {
-  STUDIES,
   GLOBAL_NOTIFICATIONS_EKID,
-  NOTIFICATIONS_ENABLED_STUDIES
+  NOTIFICATIONS_ENABLED_STUDIES,
+  PART_OF_ASSOCIATION_EKID_MAP,
+  STUDIES
 } = STUDIES_REDUCER_CONSTANTS;
 
 const INITIAL_STATE :Map<*, *> = fromJS({
@@ -95,11 +86,11 @@ const INITIAL_STATE :Map<*, *> = fromJS({
   },
   [GLOBAL_NOTIFICATIONS_EKID]: undefined,
   [NOTIFICATIONS_ENABLED_STUDIES]: Set(),
+  [PART_OF_ASSOCIATION_EKID_MAP]: Map(),
   [STUDIES]: Map(),
   associationKeyIds: Map(),
   participantEntitySetIds: Map(),
   participants: Map(),
-  studyNotifications: Map()
 });
 
 export default function studiesReducer(state :Map<*, *> = INITIAL_STATE, action :Object) {
@@ -137,17 +128,18 @@ export default function studiesReducer(state :Map<*, *> = INITIAL_STATE, action 
           if (state.hasIn([CREATE_STUDY, seqAction.id])) {
             const {
               notificationsEnabled,
+              partOfEntityKeyId,
               studyEntityData,
-              studyEntityKeyId,
               studyId
             } = seqAction.value;
 
             const notificationEnabledStudies = state.get(NOTIFICATIONS_ENABLED_STUDIES, Set());
 
             return state
-              .setIn([STUDIES, studyId], fromJS(studyEntityData))
               .set(NOTIFICATIONS_ENABLED_STUDIES,
-                notificationsEnabled ? notificationEnabledStudies.add(studyEntityKeyId) : notificationEnabledStudies)
+                notificationsEnabled ? notificationEnabledStudies.add(studyId) : notificationEnabledStudies)
+              .setIn([STUDIES, studyId], fromJS(studyEntityData))
+              .setIn([PART_OF_ASSOCIATION_EKID_MAP, studyId], partOfEntityKeyId)
               .setIn([CREATE_STUDY, 'requestState'], RequestStates.SUCCESS);
           }
           return state;
@@ -163,26 +155,25 @@ export default function studiesReducer(state :Map<*, *> = INITIAL_STATE, action 
         REQUEST: () => state.setIn([UPDATE_STUDY, 'requestState'], RequestStates.PENDING),
         SUCCESS: () => {
           const {
-            notificationId,
-            notificationEntitySetId,
+            notificationsEnabled,
             partOfEntityKeyId,
-            partOfEntitySetId,
-            studyEntityData
+            studyEntityData,
+            studyId
           } = seqAction.value;
 
-          const studyId :UUID = getIn(studyEntityData, [STUDY_ID, 0]);
-          const studyEntityKeyId :UUID = getIn(studyEntityData, [OPENLATTICE_ID_FQN, 0]);
+          let notificationEnabledStudies = state.get(NOTIFICATIONS_ENABLED_STUDIES, Set()).asMutable();
 
-          const notificationsMap = Map().withMutations((map) => {
-            map
-              .setIn(['associationEntitySet', 'id'], partOfEntitySetId)
-              .setIn(['neighborEntitySet', 'id'], notificationEntitySetId)
-              .setIn(['associationDetails', OPENLATTICE_ID_FQN], [partOfEntityKeyId])
-              .setIn(['associationDetails', NOTIFICATION_ID], [notificationId]);
-          });
+          if (notificationsEnabled) {
+            notificationEnabledStudies = notificationEnabledStudies.add(studyId);
+          }
+          else {
+            notificationEnabledStudies = notificationEnabledStudies.delete(studyId);
+          }
+
           return state
-            .setIn(['studies', studyId], fromJS(studyEntityData))
-            .setIn(['studyNotifications', studyEntityKeyId], notificationsMap)
+            .set(NOTIFICATIONS_ENABLED_STUDIES, notificationEnabledStudies.asImmutable())
+            .setIn([STUDIES, studyId], fromJS(studyEntityData))
+            .setIn([PART_OF_ASSOCIATION_EKID_MAP, studyId], partOfEntityKeyId)
             .setIn([UPDATE_STUDY, 'requestState'], RequestStates.SUCCESS);
         },
         FAILURE: () => state.setIn([UPDATE_STUDY, 'requestState'], RequestStates.FAILURE)
@@ -307,9 +298,13 @@ export default function studiesReducer(state :Map<*, *> = INITIAL_STATE, action 
       return getStudyNotificationStatus.reducer(state, action, {
         REQUEST: () => state.setIn([GET_STUDY_NOTIFICATION_STATUS, 'requestState'], RequestStates.PENDING),
         FAILURE: () => state.setIn([GET_STUDY_NOTIFICATION_STATUS, 'requestState'], RequestStates.FAILURE),
-        SUCCESS: () => state
-          .setIn([GET_STUDY_NOTIFICATION_STATUS, 'requestState'], RequestStates.SUCCESS)
-          .set(NOTIFICATIONS_ENABLED_STUDIES, Set(seqAction.value))
+        SUCCESS: () => {
+          const { studiesWithNotifications, associationEKIDMap } = seqAction.value;
+          return state
+            .set(NOTIFICATIONS_ENABLED_STUDIES, studiesWithNotifications)
+            .set(PART_OF_ASSOCIATION_EKID_MAP, associationEKIDMap)
+            .setIn([GET_STUDY_NOTIFICATION_STATUS, 'requestState'], RequestStates.SUCCESS);
+        }
       });
     }
 

--- a/src/containers/studies/StudiesSagas.js
+++ b/src/containers/studies/StudiesSagas.js
@@ -473,7 +473,9 @@ function* updateStudyWorker(action :SequenceAction) :Generator<*, *, *> {
     }
     else {
       formData = setIn(formData,
-        [getPageSectionKey(1, 1), getEntityAddressKey(0, CHRONICLE_PARTOF, NOTIFICATION_ID)], partOfAssociationVal);
+        [getPageSectionKey(1, 1), getEntityAddressKey(
+          partOfEntityKeyId, CHRONICLE_PARTOF, ID_FQN
+        )], partOfAssociationVal);
     }
 
     // remove notification_enabled property since it is not a part of chronicle_studies entity set

--- a/src/containers/study/StudyDetailsContainer.js
+++ b/src/containers/study/StudyDetailsContainer.js
@@ -5,8 +5,7 @@
 import React from 'react';
 
 import styled from 'styled-components';
-import { Map } from 'immutable';
-import { Constants } from 'lattice';
+import { Map, Set } from 'immutable';
 import { Colors } from 'lattice-ui-kit';
 import { useDispatch, useSelector } from 'react-redux';
 import { Route, Switch } from 'react-router';
@@ -20,11 +19,13 @@ import * as Routes from '../../core/router/Routes';
 import { PROPERTY_TYPE_FQNS } from '../../core/edm/constants/FullyQualifiedNames';
 import { getIdFromMatch } from '../../core/router/RouterUtils';
 import { goToRoot } from '../../core/router/RoutingActions';
+import { STUDIES_REDUCER_CONSTANTS } from '../../utils/constants/ReduxConstants';
 
-const { NOTIFICATION_ID, STUDY_NAME } = PROPERTY_TYPE_FQNS;
+const { STUDY_NAME } = PROPERTY_TYPE_FQNS;
+
+const { NOTIFICATIONS_ENABLED_STUDIES, STUDIES } = STUDIES_REDUCER_CONSTANTS;
+
 const { NEUTRALS, PURPLES } = Colors;
-
-const { OPENLATTICE_ID_FQN } = Constants;
 
 const StudyNameWrapper = styled.h2`
   align-items: flex-start;
@@ -73,20 +74,16 @@ const StudyDetailsContainer = (props :Props) => {
   const {
     match,
   } = props;
-
-  const studyUUID :UUID = getIdFromMatch(match) || '';
   const dispatch = useDispatch();
 
-  const study = useSelector((state) => state.getIn(['studies', 'studies', studyUUID], Map()));
-  const studyEntityKeyId = study.getIn([OPENLATTICE_ID_FQN, 0]);
+  const studyUUID :UUID = getIdFromMatch(match) || '';
 
-  const notificationId = useSelector(
-    (state) => state.getIn(
-      ['studies', 'studyNotifications', studyEntityKeyId, 'associationDetails', NOTIFICATION_ID, 0]
-    )
+  const study = useSelector((state) => state.getIn([STUDIES, STUDIES, studyUUID], Map()));
+  const notificationsEnabledStudies = useSelector(
+    (state) => state.getIn([STUDIES, NOTIFICATIONS_ENABLED_STUDIES], Set())
   );
 
-  const notificationsEnabled :boolean = notificationId === studyUUID;
+  const notificationsEnabled :boolean = notificationsEnabledStudies.has(studyUUID);
 
   if (!study) {
     dispatch(goToRoot());

--- a/src/core/edm/EDMUtils.js
+++ b/src/core/edm/EDMUtils.js
@@ -13,7 +13,10 @@ const selectEntityType = (entityTypeFQN :FQN) => (state :Map) => {
   return state.getIn(['edm', 'entityTypes', entityTypeIndex]);
 };
 
+const selectEntitySetId = (esName :string) => (state :Map) => state.getIn(['edm', 'entitySetIds', esName]);
+
 export {
   selectEntityType,
-  selectEntityTypeId
+  selectEntityTypeId,
+  selectEntitySetId
 };

--- a/src/core/edm/EDMUtils.js
+++ b/src/core/edm/EDMUtils.js
@@ -13,10 +13,15 @@ const selectEntityType = (entityTypeFQN :FQN) => (state :Map) => {
   return state.getIn(['edm', 'entityTypes', entityTypeIndex]);
 };
 
+const selectPropertyTypeId = (propertyTypeFQN :FQN) => (state :Map) => {
+  return state.getIn(['edm', 'propertyTypeIds', propertyTypeFQN]);
+};
+
 const selectEntitySetId = (esName :string) => (state :Map) => state.getIn(['edm', 'entitySetIds', esName]);
 
 export {
   selectEntityType,
   selectEntityTypeId,
-  selectEntitySetId
+  selectEntitySetId,
+  selectPropertyTypeId
 };

--- a/src/core/edm/constants/EntitySetNames.js
+++ b/src/core/edm/constants/EntitySetNames.js
@@ -4,6 +4,7 @@
 
 const ASSOCIATION_ENTITY_SET_NAMES = {
   PARTICIPATED_IN: 'chronicle_participated_in',
+  CHRONICLE_PARTOF: 'chronicle_partof'
 };
 
 const ENTITY_SET_NAMES = {
@@ -11,6 +12,7 @@ const ENTITY_SET_NAMES = {
   CHRONICLE_DEVICES: 'chronicle_device',
   CHRONICLE_STUDIES: 'chronicle_study',
   PREPROCESSED_DATA: 'chronicle_preprocessed_app_data',
+  CHRONICLE_NOTIFICATIONS: 'chronicle_notifications',
 };
 
 const ENTITY_SET_NAMES_LIST = [];

--- a/src/core/edm/constants/FullyQualifiedNames.js
+++ b/src/core/edm/constants/FullyQualifiedNames.js
@@ -35,7 +35,8 @@ const PROPERTY_TYPE_FQNS = {
   // notifications
   NOTIFICATION_ID: new FullyQualifiedName('ol.id'),
   NOTIFICATION_DESCRIPTION: new FullyQualifiedName('ol.description'),
-  NOTIFICATION_ENABLED: new FullyQualifiedName('ol.status')
+  NOTIFICATION_ENABLED: new FullyQualifiedName('ol.status'),
+  ID_FQN: new FullyQualifiedName('ol.id'),
 };
 
 export {

--- a/src/utils/constants/ReduxConstants.js
+++ b/src/utils/constants/ReduxConstants.js
@@ -1,0 +1,11 @@
+// @flow
+
+const STUDIES_REDUCER_CONSTANTS = {
+  STUDIES: 'studies',
+  GLOBAL_NOTIFICATIONS_EKID: 'globalNotificationsEKID',
+  NOTIFICATIONS_ENABLED_STUDIES: 'notificationsEnabledStudies',
+};
+
+export {
+  STUDIES_REDUCER_CONSTANTS
+};

--- a/src/utils/constants/ReduxConstants.js
+++ b/src/utils/constants/ReduxConstants.js
@@ -4,6 +4,7 @@ const STUDIES_REDUCER_CONSTANTS = {
   STUDIES: 'studies',
   GLOBAL_NOTIFICATIONS_EKID: 'globalNotificationsEKID',
   NOTIFICATIONS_ENABLED_STUDIES: 'notificationsEnabledStudies',
+  PART_OF_ASSOCIATION_EKID_MAP: 'partOfAssociationEKIDMap'
 };
 
 export {


### PR DESCRIPTION
PR:

Rewrite create study / update study logic to comply with a single notifications entity set for all studies as opposed to one per study


