### PR TITLE
questionnaire details view: handle rrule with freq DAILY and no BYDAY options

### DIFF
--- a/src/containers/questionnaires/utils/index.js
+++ b/src/containers/questionnaires/utils/index.js
@@ -49,6 +49,8 @@ const {
   VALUES_FQN
 } = PROPERTY_TYPE_FQNS;
 
+const rruleWeekDayConsts = [RRule.MO, RRule.TU, RRule.WE, RRule.TH, RRule.FR, RRule.SA, RRule.SU];
+
 // return an Object with title, description, numMultipleChoice and numSingleAnswer questions
 const getQuestionnaireSummaryFromForm = (formData :Object = {}) => {
   const result = {};
@@ -74,7 +76,6 @@ const getQuestionnaireSummaryFromForm = (formData :Object = {}) => {
 const createRecurrenceRuleSetFromFormData = (formData :Object) => {
   const psk = getPageSectionKey(3, 1);
 
-  const rruleWeekDayConsts = [RRule.MO, RRule.TU, RRule.WE, RRule.TH, RRule.FR, RRule.SA, RRule.SU];
   // $FlowFixMe
   const mapper = Info.weekdays().reduce((result, day, index) => ({
     ...result,
@@ -105,13 +106,15 @@ const createRecurrenceRuleSetFromFormData = (formData :Object) => {
 
 // parse a rruleSet string and get days of week + times
 const getWeekDaysAndTimesFromRruleSet = (rruleSet :string) => {
+
   const rrules :string[] = rruleSet.split('RRULE:').filter((token) => isNonEmptyString(token));
   // get week days
   // the days of the week are the same in all the individual rules in the rrruleSet,
   // so we only need to read the values from the first rrule
   // $FlowFixMe
   const weekdays = Info.weekdays();
-  const weekDays = RRule.parseString(rrules[0]).byweekday
+  const selectedWeekdays = RRule.parseString(rrules[0]).byweekday || rruleWeekDayConsts;
+  const weekDays = selectedWeekdays
     .map((day) => day.weekday)
     .sort()
     .map((index) => weekdays[index]);

--- a/src/containers/questionnaires/utils/index.js
+++ b/src/containers/questionnaires/utils/index.js
@@ -110,14 +110,20 @@ const getWeekDaysAndTimesFromRruleSet = (rruleSet :string) => {
   const rrules :string[] = rruleSet.split('RRULE:').filter((token) => isNonEmptyString(token));
   // get week days
   // the days of the week are the same in all the individual rules in the rrruleSet,
-  // so we only need to read the values from the first rrule
+  // so we only need to parse the the first rrule
+  const rruleOptions = RRule.parseString(rrules[0]);
+  let weekdayOptions :?Object[] = rruleOptions.byweekday;
+  if (!weekdayOptions && rruleOptions.freq === RRule.DAILY) {
+    weekdayOptions = rruleWeekDayConsts;
+  }
+
   // $FlowFixMe
-  const weekdays = Info.weekdays();
-  const selectedWeekdays = RRule.parseString(rrules[0]).byweekday || rruleWeekDayConsts;
-  const weekDays = selectedWeekdays
+  const allWeekdays = Info.weekdays();
+  // $FlowFixMe
+  const weekdays = (weekdayOptions || [])
     .map((day) => day.weekday)
     .sort()
-    .map((index) => weekdays[index]);
+    .map((index) => allWeekdays[index]);
 
   // $FlowFixMe
   const times = rrules
@@ -126,7 +132,7 @@ const getWeekDaysAndTimesFromRruleSet = (rruleSet :string) => {
     .map((date) => date.toLocaleString(DateTime.TIME_SIMPLE))
     .sort();
 
-  return [weekDays, times];
+  return [weekdays, times];
 };
 
 const createPreviewQuestionEntities = (formData :Object) => {


### PR DESCRIPTION
PR: when no BYDAY option is in a rrule whose freq = DAILY, show all days of the week

For example these two are equivalent: 
1) `RRULE:FREQ=DAILY;BYHOUR=18;BYMINUTE=45`
2) `RRULE:FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYHOUR=18;BYMINUTE=45