### PR TITLE
install flow-bin version 0.131.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10063,9 +10063,9 @@
       "dev": true
     },
     "flow-bin": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.132.0.tgz",
-      "integrity": "sha512-S1g/vnAyNaLUdajmuUHCMl30qqye12gS6mr4LVyswf1k+JDF4efs6SfKmptuvnpitF3LGCVf0TIffChP8ljwnw==",
+      "version": "0.131.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.131.0.tgz",
+      "integrity": "sha512-fZmoIBcDrtLhy/NNMxwJysSYzMr1ksRcAOMi3AHSoYXfcuQqTvhGJx+wqjlIOqIwz8RRYm8J4V4JrSJbIKP+Xg==",
       "dev": true
     },
     "flush-write-stream": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "eslint-plugin-react": "~7.20.0",
     "eslint-plugin-react-hooks": "~4.1.0",
     "file-loader": "~6.0.0",
-    "flow-bin": "~0.132.0",
+    "flow-bin": "~0.131.0",
     "html-webpack-plugin": "~4.3.0",
     "import-sort-style-openlattice": "~0.1.0",
     "jest": "~26.4.2",


### PR DESCRIPTION
flow-bin 0.132.0 disallows any-typed values type annotations (https://github.com/facebook/flow/releases/tag/v0.132.0) - hence doesn't work well with immutable collections annotations