### PR TITLE
Fix time use diary data download bug

### DIFF
--- a/src/containers/tud/TimeUseDiarySagas.js
+++ b/src/containers/tud/TimeUseDiarySagas.js
@@ -245,7 +245,7 @@ function* downloadTudResponsesWorker(action :SequenceAction) :Saga<*> {
       fromJS(response.data).forEach((neighbors :List, submissionId :UUID) => {
         neighbors.forEach((neighbor :Map) => {
           const entity = neighbor.get('neighborDetails');
-          const values = getPropertyValue(entity, VALUES_FQN);
+          const values = getPropertyValue(entity, VALUES_FQN, List());
           const answerId = getEntityKeyId(entity);
 
           mutator.set(answerId, values);


### PR DESCRIPTION
PR:

pass fallback value to `getPropertyValue` in place of the default empty string
