### PR TITLE
Time use diary bug fix

### DIFF
--- a/src/containers/tud/components/QuestionnaireForm.js
+++ b/src/containers/tud/components/QuestionnaireForm.js
@@ -80,10 +80,12 @@ const removeExtraData = (formRef :Object, pagedData, page :number) => {
     if (!currEndDateTime.equals(dayEndTime)) {
       return;
     }
+
     const pages = Object.keys(formData)
-      .map((key) => parsePageSectionKey(key))
-      .map((parsedResult) => parsedResult.page)
-      .map((pageStr) => Number(pageStr));
+      .map((key) => {
+        const parsed = parsePageSectionKey(key);
+        return Number(parsed.page);
+      });
 
     let toRemoveStartIndex = page + 1;
     // if the next page has night activity page data, skip

--- a/src/containers/tud/components/QuestionnaireForm.js
+++ b/src/containers/tud/components/QuestionnaireForm.js
@@ -3,10 +3,10 @@
 import React from 'react';
 
 import styled from 'styled-components';
-import { getIn, setIn, merge } from 'immutable';
+import { getIn, merge, setIn } from 'immutable';
 import { DataProcessingUtils, Form } from 'lattice-fabricate';
 import { Button } from 'lattice-ui-kit';
-import { set } from 'lodash';
+import { set, unset } from 'lodash';
 import { DateTime } from 'luxon';
 import { useDispatch } from 'react-redux';
 import { RequestStates } from 'redux-reqseq';
@@ -28,7 +28,7 @@ import {
   selectTimeByPageAndKey
 } from '../utils';
 
-const { getPageSectionKey } = DataProcessingUtils;
+const { getPageSectionKey, parsePageSectionKey } = DataProcessingUtils;
 
 const { READING, MEDIA_USE } = PRIMARY_ACTIVITIES;
 
@@ -59,6 +59,50 @@ const ButtonRow = styled.div`
 `;
 
 /*
+ * This code fixes an issue where the survey enters an error state after a user fills out the survey
+ * and later changes the day end time value. If the day end time is changed such that certain sections
+ * of the formRef state contain invalid data (the start/end values are out of range), then this will cause
+ * validateAndSubmit to fail, hence the need to remove such sections. This deletion need only take place
+ * just before we enter the nightActivity portion of the survey. At this point, for all x s.t x > page
+ * only x == page + 1 can be expected to contain any data
+  (and it should be nightActivity data otherwise it also needs to be deleted)
+ */
+
+const removeExtraData = (formRef :Object, pagedData, page :number) => {
+  const psk = getPageSectionKey(page, 0);
+  const dayEndTime :?DateTime = selectTimeByPageAndKey(DAY_SPAN_PAGE, DAY_END_TIME, pagedData);
+  const formData :Object = formRef?.current?.state?.formData || {};
+
+  const currEndTime = formData[psk]?.[ACTIVITY_END_TIME];
+
+  if (dayEndTime && currEndTime) {
+    const currEndDateTime :DateTime = DateTime.fromSQL(currEndTime);
+    if (!currEndDateTime.equals(dayEndTime)) {
+      return;
+    }
+    const pages = Object.keys(formData)
+      .map((key) => parsePageSectionKey(key))
+      .map((parsedResult) => parsedResult.page)
+      .map((pageStr) => Number(pageStr));
+
+    let toRemoveStartIndex = page + 1;
+    // if the next page has night activity page data, skip
+    const nextPageData = formData[getPageSectionKey(toRemoveStartIndex, 0)] || {};
+    if (Object.keys(nextPageData).includes(SLEEP_ARRANGEMENT)) {
+      toRemoveStartIndex += 1;
+    }
+
+    const toRemovePsks = pages
+      .filter((index) => index >= toRemoveStartIndex)
+      .map((index) => getPageSectionKey(index, 0));
+
+    toRemovePsks.forEach((toRemovePsk) => {
+      unset(formData, toRemovePsk);
+    });
+  }
+};
+
+/*
  * Return true if the current page should display a summary of activities
  * Summary page is displayed after night activity page, hence page - 2 accounts for the night activity page
  */
@@ -85,20 +129,28 @@ const forceFormDataStateUpdate = (formRef :Object, pagedData :Object = {}, page 
   const prevEndTime = selectTimeByPageAndKey(
     page - 1, (page === FIRST_ACTIVITY_PAGE ? DAY_START_TIME : ACTIVITY_END_TIME), pagedData
   );
+  const activityStartTime = selectTimeByPageAndKey(
+    page - 1, (page === FIRST_ACTIVITY_PAGE ? DAY_START_TIME : ACTIVITY_START_TIME), pagedData
+  );
 
   // current page already contains form data
-  if (Object.keys(pagedData).includes(psk) && prevEndTime.isValid) {
-    const formattedTime = prevEndTime.toLocaleString(DateTime.TIME_24_SIMPLE);
+  if (Object.keys(pagedData).includes(psk) && prevEndTime.isValid && activityStartTime.isValid) {
+    const formattedEndTime = prevEndTime.toLocaleString(DateTime.TIME_24_SIMPLE);
+    const formattedStartTime = activityStartTime.toLocaleString(DateTime.TIME_24_SIMPLE);
+
     const sectionData = pagedData[psk];
+    const formData = formRef?.current?.state?.formData || {};
 
     // current page contains followup questions for selected primary activity
     if (Object.keys(sectionData).includes(HAS_FOLLOWUP_QUESTIONS)) {
-      set(formRef, ['current', 'state', 'formData', psk, ACTIVITY_END_TIME], formattedTime);
+      set(formData, [psk, ACTIVITY_END_TIME], formattedEndTime);
+      set(formData, [psk, ACTIVITY_START_TIME], formattedStartTime);
+      removeExtraData(formRef, pagedData, page);
     }
 
     // current page is night activity page
     else if (!Object.keys(sectionData).includes(SLEEP_ARRANGEMENT)) {
-      set(formRef, ['current', 'state', 'formData', psk, ACTIVITY_START_TIME], formattedTime);
+      set(formData, [psk, ACTIVITY_START_TIME], formattedEndTime);
     }
   }
 };


### PR DESCRIPTION
PR:
This PR fixes an issue where the survey form entered an error state when a user, after filling out the survey, modifies the day start/end times in such a way as to cause certain data sections in PagedData to be out of range, thus interfering with validate on submit.



