### PR TITLE
Fix Hebrew translations not loading; scope RTL to participant routes.

### DIFF
--- a/config/webpack/webpack.config.base.js
+++ b/config/webpack/webpack.config.base.js
@@ -85,20 +85,6 @@ module.exports = (env) => {
       rules: [
         BABEL_LOADER,
         {
-          test: /translation\.json$/,
-          type: 'javascript/auto',
-          use: [{
-            loader: 'file-loader',
-            options: {
-              name: (filePath) => {
-                // filePath = "/path/to/src/core/i18n/en/translation.json"
-                const [language] = filePath.split('i18n/')[1].split('/');
-                return `static/i18n/${language}/[name].[contenthash].json`;
-              },
-            },
-          }],
-        },
-        {
           generator: {
             filename: (
               env.production

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "history": "~4.10.0",
         "i18next": "~20.2.2",
         "i18next-browser-languagedetector": "~6.1.0",
-        "i18next-http-backend": "~1.2.1",
         "immutable": "4.0.0-rc.10",
         "js-cookie": "~2.2.1",
         "jwt-decode": "~3.1.0",
@@ -6291,22 +6290,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
-      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
-      "dependencies": {
-        "node-fetch": "2.6.1"
-      }
-    },
-    "node_modules/cross-fetch/node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -9427,14 +9410,6 @@
       "integrity": "sha512-Svm+MduCElO0Meqpj1kJAriTC6OhI41VhlT/A0UPjGoPZBhAHIaGE5EfsHlTpgdH09UVX7rcc72pSDDBeKSQQA==",
       "dependencies": {
         "@babel/runtime": "^7.19.0"
-      }
-    },
-    "node_modules/i18next-http-backend": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-1.2.8.tgz",
-      "integrity": "sha512-WyD+P1fDa4Jwk+NN4lnm6vUkjl0R1gJCfSmXCja/cMQSJRVOGA+mVdzj4m6i3XpOFtTHSZi71B7+XJhsw6szeA==",
-      "dependencies": {
-        "cross-fetch": "3.1.4"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "history": "~4.10.0",
     "i18next": "~20.2.2",
     "i18next-browser-languagedetector": "~6.1.0",
-    "i18next-http-backend": "~1.2.1",
     "immutable": "4.0.0-rc.10",
     "js-cookie": "~2.2.1",
     "lodash": "~4.17.21",

--- a/src/containers/app/AppContainer.js
+++ b/src/containers/app/AppContainer.js
@@ -50,6 +50,14 @@ const AppContainer = () => {
     dispatch(initializeApplication());
   }, [dispatch]);
 
+  // The operator UI is always LTR. Reset in case a prior participant
+  // session (TUD in Hebrew) flipped <html dir> on this tab.
+  useEffect(() => {
+    if (document && document.documentElement) {
+      document.documentElement.dir = 'ltr';
+    }
+  }, []);
+
   const onLogout = () => {
     dispatch(logout());
     // eslint-disable-next-line no-undef

--- a/src/core/i18n/index.js
+++ b/src/core/i18n/index.js
@@ -1,4 +1,3 @@
-import Backend from 'i18next-http-backend';
 import Cookies from 'js-cookie';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import i18n from 'i18next';
@@ -13,9 +12,25 @@ const SUPPORTED_BASE_CODES = new Set(
   Object.values(LanguageCodes).map((code) => code.split('-')[0])
 );
 
+const PARTICIPANT_HASH_PREFIXES = ['#/time-use-diary', '#/survey'];
+
+// The app uses HashRouter, so query params live after the '#'.
+const getHashQueryParams = () => {
+  if (typeof window === 'undefined' || !window.location) return new URLSearchParams();
+  const hash = window.location.hash || '';
+  const qIndex = hash.indexOf('?');
+  if (qIndex === -1) return new URLSearchParams();
+  return new URLSearchParams(hash.substring(qIndex + 1));
+};
+
+const isParticipantRoute = () => {
+  if (typeof window === 'undefined' || !window.location) return false;
+  const hash = window.location.hash || '';
+  return PARTICIPANT_HASH_PREFIXES.some((prefix) => hash.startsWith(prefix));
+};
+
 const getUrlLanguageCode = () => {
-  if (typeof window === 'undefined' || !window.location) return undefined;
-  const params = new URLSearchParams(window.location.search);
+  const params = getHashQueryParams();
   const lang = params.get('lang');
   if (!lang || !SUPPORTED_BASE_CODES.has(lang)) return undefined;
   const gender = params.get('gender') || undefined;
@@ -29,19 +44,20 @@ if (!defaultLanguageCookie || defaultLanguageCookie === 'null' || defaultLanguag
 const defaultLanguageCode = getUrlLanguageCode() || defaultLanguageCookie || LanguageCodes.ENGLISH;
 
 if (typeof document !== 'undefined' && document.documentElement) {
-  document.documentElement.dir = defaultLanguageCode.startsWith('he') ? 'rtl' : 'ltr';
+  const shouldRtl = defaultLanguageCode.startsWith('he') && isParticipantRoute();
+  document.documentElement.dir = shouldRtl ? 'rtl' : 'ltr';
 }
+
+const resources = Object.fromEntries(
+  Object.entries(translations).map(([code, t]) => [code, { translation: t }])
+);
 
 i18n
   .use(initReactI18next)
-  .use(Backend)
   .use(LanguageDetector)
   .init({
     lng: defaultLanguageCode,
-    backend: {
-      loadPath: (language) => translations[language]
-    },
+    resources,
     fallbackLng: LanguageCodes.ENGLISH,
     debug: __ENV_DEV__, // eslint-disable-line no-undef
-  })
-  .then(() => i18n.loadLanguages(Object.keys(translations)));
+  });


### PR DESCRIPTION
The Hebrew JSON files were correct, but webpack's file-loader was emitting them as separate URL assets that i18next-http-backend then fetched at runtime. Tests passed because Jest doesn't apply file-loader (imports were objects), so the production loading path was never exercised by tests - if the fetch failed, the user saw English with no test signal. Now translations are bundled inline via i18next's resources config; no runtime fetch, no http-backend.

Also fixes two related issues:

- Bootstrap was parsing URL params from window.location.search, but the app uses HashRouter so ?lang= lives after the '#'. The participant-side TUD container already handled this via react-router's useLocation, but the bootstrap fast-path didn't.

- <html dir=rtl> was being set globally whenever the cookie said Hebrew, which broke the operator-side ParticipantsTable (its last column is pinned with `position: sticky; right: 0`, invisible in RTL). Bootstrap now only flips dir to rtl when on a participant route, and AppContainer resets dir=ltr on mount so operator navigation away from a Hebrew TUD session restores LTR.